### PR TITLE
Fix ApiAi Middleware (#285)

### DIFF
--- a/src/Mpociot/BotMan/Middleware/ApiAi.php
+++ b/src/Mpociot/BotMan/Middleware/ApiAi.php
@@ -23,7 +23,7 @@ class ApiAi implements MiddlewareInterface
     protected $lastResponseHash;
 
     /** @var string */
-    protected $apiUrl = 'https://api.api.ai/v1/query';
+    protected $apiUrl = 'https://api.api.ai/v1/query?v=20150910';
 
     /** @var bool */
     protected $listenForAction = false;
@@ -96,7 +96,7 @@ class ApiAi implements MiddlewareInterface
     {
         $response = $this->getResponse($message);
 
-        $reply = isset($response->result->speech) ? $response->result->speech : '';
+        $reply = isset($response->result->fulfillment->speech) ? $response->result->fulfillment->speech : '';
         $action = isset($response->result->action) ? $response->result->action : '';
         $actionIncomplete = isset($response->result->actionIncomplete) ? (bool) $response->result->actionIncomplete : false;
         $intent = isset($response->result->metadata->intentName) ? $response->result->metadata->intentName : '';

--- a/tests/Middleware/ApiAiTest.php
+++ b/tests/Middleware/ApiAiTest.php
@@ -28,7 +28,9 @@ class ApiAiTest extends PHPUnit_Framework_TestCase
 
         $apiResponse = [
             'result' => [
-                'speech' => 'api reply text',
+                'fulfillment' => [
+                    'speech' => 'api reply text',
+                ],
                 'action' => 'api action name',
                 'metadata' => [
                     'intentName' => 'name of the matched intent',
@@ -43,7 +45,7 @@ class ApiAiTest extends PHPUnit_Framework_TestCase
         $http = m::mock(Curl::class);
         $http->shouldReceive('post')
             ->once()
-            ->with('https://api.api.ai/v1/query', [], [
+            ->with('https://api.api.ai/v1/query?v=20150910', [], [
                 'query' => [$messageText],
                 'sessionId' => md5($messageChannel),
                 'lang' => 'en',
@@ -73,7 +75,9 @@ class ApiAiTest extends PHPUnit_Framework_TestCase
 
         $apiResponse = [
             'result' => [
-                'speech' => 'api reply text',
+                'fulfillment' => [
+                    'speech' => 'api reply text',
+                ],
                 'action' => 'my_api_ai_action_name',
                 'metadata' => [
                     'intentName' => 'name of the matched intent',
@@ -102,7 +106,9 @@ class ApiAiTest extends PHPUnit_Framework_TestCase
 
         $apiResponse = [
             'result' => [
-                'speech' => 'api reply text',
+                'fulfillment' => [
+                    'speech' => 'api reply text',
+                ],
                 'action' => 'my_api_ai_action_name',
                 'metadata' => [
                     'intentName' => 'name of the matched intent',


### PR DESCRIPTION
* Add extras parameter action Incomplete ApiAi

* Add extras parameter action Incomplete ApiAi test

* Add version parameter on request url.
This parameters is required. Must be used as a URL parameter.

See: https://docs.api.ai/docs/query#post-query

* Fix tests

* Fix tests

* Fix reply fulfillment speech. (New Version)